### PR TITLE
GameCard Test Suite

### DIFF
--- a/src/entities/CommonCardFactory.java
+++ b/src/entities/CommonCardFactory.java
@@ -58,7 +58,7 @@ public class CommonCardFactory implements CardFactory {
         } else {
             weaknessValue = "0";
         }
-        cardWeaknesses.put(cardWeaknessesObj.getString("name"), Integer.parseInt(weaknessValue));
+        cardWeaknesses.put(cardWeaknessesObj.getString("type"), Integer.parseInt(weaknessValue));
 
 //        cardWeaknesses.put(cardWeaknessesObj.getString("type"), cardWeaknessesObj.getInt("value"));
 
@@ -72,7 +72,7 @@ public class CommonCardFactory implements CardFactory {
             } else {
                 resistanceValue = "0";
             }
-            cardResistances.put(cardResistancesObj.getString("name"), Integer.parseInt(resistanceValue));
+            cardResistances.put(cardResistancesObj.getString("type"), Integer.parseInt(resistanceValue));
 
 //            cardResistances.put(cardResistancesObj.getString("type"), cardResistancesObj.getInt("value"));
         }

--- a/src/entities/GameCard.java
+++ b/src/entities/GameCard.java
@@ -46,14 +46,12 @@ public class GameCard implements GamePokemon {
         return onField;
     }
 
-    public void faint() {
+    public void takeDamage(Integer damage) {
+        this.setHP(this.getHP() - damage);
         if (this.getHP() <= 0) {
             this.fainted = true;
         }
-    }
 
-    public void takeDamage(Integer damage) {
-        this.setHP(this.getHP() - damage);
     }
 
     public void swap() {

--- a/src/entities/GamePokemon.java
+++ b/src/entities/GamePokemon.java
@@ -14,8 +14,6 @@ public interface GamePokemon {
 
     public boolean isOnField();
 
-    public void faint();
-
     public void takeDamage(Integer damage);
 
     public void swap();

--- a/test/entities/GameCardTest.java
+++ b/test/entities/GameCardTest.java
@@ -3,6 +3,9 @@ package entities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class GameCardTest {
@@ -23,33 +26,54 @@ class GameCardTest {
 
     @Test
     void getType() {
+        assertEquals("Colorless", gameCard.getType().getOverallType());
     }
 
     @Test
     void getHP() {
+        assertEquals(150, gameCard.getHP());
     }
 
     @Test
-    void getAttack() {
+    void getAttackName() {
+        Set<String> keys = gameCard.getAttack().keySet();
+        Integer damage = 0;
+        String attackName = "";
+        for (String key : keys) {
+            damage = gameCard.getAttack().get(key);
+            attackName = key;
+        }
+        assertEquals("Thudding Press", attackName);
+        assertEquals(130, damage);
     }
 
     @Test
     void hasFainted() {
+        assertEquals(false, gameCard.hasFainted());
     }
 
     @Test
     void isOnField() {
+        assertFalse(gameCard.isOnField());
     }
 
     @Test
-    void faint() {
+    void DamageToFaint() {
+        gameCard.takeDamage(7000);
+        assertTrue(gameCard.hasFainted());
     }
 
     @Test
     void takeDamage() {
+        gameCard.takeDamage(1);
+        assertEquals(149, gameCard.getHP());
     }
 
     @Test
     void swap() {
+        gameCard.swap();
+        assertTrue(gameCard.isOnField());
+        gameCard.swap();
+        assertFalse(gameCard.isOnField());
     }
 }

--- a/test/entities/GameCardTest.java
+++ b/test/entities/GameCardTest.java
@@ -1,4 +1,55 @@
-import static org.junit.Assert.*;
-public class GameCardTest {
-  
+package entities;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GameCardTest {
+    Card card;
+    GamePokemon gameCard;
+
+    @BeforeEach
+    void init() {
+        CardFactory cardFactory = new CommonCardFactory();
+        card = cardFactory.create("sv3pt5-143","Snorlax");
+        gameCard = new GameCard(card);
+    }
+
+    @Test
+    void getName() {
+        assertEquals("Snorlax", gameCard.getName());
+    }
+
+    @Test
+    void getType() {
+    }
+
+    @Test
+    void getHP() {
+    }
+
+    @Test
+    void getAttack() {
+    }
+
+    @Test
+    void hasFainted() {
+    }
+
+    @Test
+    void isOnField() {
+    }
+
+    @Test
+    void faint() {
+    }
+
+    @Test
+    void takeDamage() {
+    }
+
+    @Test
+    void swap() {
+    }
 }


### PR DESCRIPTION
Built tests for the GameCard entity. All these tests pass **with the updated code in PR #31.** 
Also removed GameCard.faint(). I found it was better to just automatically check if a pokemon has fainted and update accordingly in GameCard.takeDamage().
